### PR TITLE
Fix SQL info constant name

### DIFF
--- a/pkg/infrastructure/jdbc_compatibility.go
+++ b/pkg/infrastructure/jdbc_compatibility.go
@@ -348,7 +348,7 @@ func (p *EnhancedSQLInfoProvider) initializeEnhancedSQLInfo() {
 	p.sqlInfo[uint32(flightsql.SqlInfoDDLCatalog)] = true
 	p.sqlInfo[uint32(flightsql.SqlInfoDDLSchema)] = true
 	p.sqlInfo[uint32(flightsql.SqlInfoDDLTable)] = true
-	p.sqlInfo[uint32(flightsql.SqlInfoAllTablesAreASelectable)] = true
+	p.sqlInfo[uint32(flightsql.SqlInfoAllTablesAreSelectable)] = true
 	p.sqlInfo[uint32(flightsql.SqlInfoTransactionsSupported)] = true
 
 	// JDBC-specific features (using available constants)

--- a/pkg/infrastructure/sql_info.go
+++ b/pkg/infrastructure/sql_info.go
@@ -60,7 +60,7 @@ func (p *SQLInfoProvider) ensureInit() {
 		// Sorting / NULL ordering
 		add(flightsql.SqlInfoNullOrdering, int64(flightsql.SqlNullOrderingSortAtStart))
 
-		add(flightsql.SqlInfoAllTablesAreASelectable, true)
+		add(flightsql.SqlInfoAllTablesAreSelectable, true)
 		add(flightsql.SqlInfoTransactionsSupported, true)
 
 		// Keywords / functions (pre‑allocated capacity improves append perf)


### PR DESCRIPTION
## Summary
- use the correct name `SqlInfoAllTablesAreSelectable`

## Testing
- `go test ./...` *(fails: go1.24 not available)*

------
https://chatgpt.com/codex/tasks/task_e_685259157b04832ea8e9897d0f00b0f9