### PR TITLE
Fix metrics interface for prepared statement handler tests

### DIFF
--- a/pkg/handlers/metrics_test.go
+++ b/pkg/handlers/metrics_test.go
@@ -1,0 +1,36 @@
+package handlers
+
+import "github.com/TFMV/hatch/pkg/infrastructure/metrics"
+
+// metricsAdapter adapts metrics.Collector to the MetricsCollector interface used in handlers.
+type metricsAdapter struct {
+	collector metrics.Collector
+}
+
+func newMetricsAdapter(c metrics.Collector) MetricsCollector {
+	return &metricsAdapter{collector: c}
+}
+
+func (m *metricsAdapter) IncrementCounter(name string, labels ...string) {
+	m.collector.IncrementCounter(name, labels...)
+}
+
+func (m *metricsAdapter) RecordHistogram(name string, value float64, labels ...string) {
+	m.collector.RecordHistogram(name, value, labels...)
+}
+
+func (m *metricsAdapter) RecordGauge(name string, value float64, labels ...string) {
+	m.collector.RecordGauge(name, value, labels...)
+}
+
+func (m *metricsAdapter) StartTimer(name string) Timer {
+	return &metricsTimerAdapter{timer: m.collector.StartTimer(name)}
+}
+
+type metricsTimerAdapter struct {
+	timer metrics.Timer
+}
+
+func (t *metricsTimerAdapter) Stop() {
+	t.timer.Stop()
+}


### PR DESCRIPTION
## Summary
- provide a metrics adapter in handler tests for using infrastructure metrics collectors

## Testing
- `go test ./...` *(fails: downloading dependencies blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685258bec220832eaadc528726b028ce