### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: Build and Test
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/TFMV/porter/security/code-scanning/1](https://github.com/TFMV/porter/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow. Since the workflow primarily performs build and test operations, it does not require write access to the repository. The minimal permissions required are `contents: read`, which allows the workflow to read repository contents. This block should be added at the root level of the workflow to apply to all jobs, as none of the jobs require additional permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
